### PR TITLE
karin_windy: Use common kernel defconf

### DIFF
--- a/aosp_sgp712.mk
+++ b/aosp_sgp712.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TARGET_KERNEL_CONFIG := aosp_kitakami_karin_windy_defconfig
-
 PRODUCT_COPY_FILES := \
     frameworks/native/data/etc/tablet_core_hardware.xml:system/etc/permissions/tablet_core_hardware.xml
 

--- a/aosp_sgp7xx_common.mk
+++ b/aosp_sgp7xx_common.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+TARGET_KERNEL_CONFIG := aosp_kitakami_karin_defconfig
+
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/karin_windy/overlay
 


### PR DESCRIPTION
specific karin_windy defconf was unified.
https://github.com/sonyxperiadev/kernel/commit/53ffd38ba9381fac5e5777ab09453b52d0785164

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: If40b0ec5ff790fb4d97d5c7cd3bc540dc9a25ea4
