### PR TITLE
karin: overlay: Add lid cover power control

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -77,6 +77,11 @@
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">10</integer>
 
+    <!-- Indicate whether closing the lid causes the device to go to sleep and opening
+         it causes the device to wake up.
+         The default is false. -->
+    <bool name="config_lidControlsSleep">true</bool>
+
     <!-- Screen brightness used to dim the screen while dozing in a very low power state.
          May be less than the minimum allowed brightness setting
          that can be set by the user. -->


### PR DESCRIPTION
This overlay entry indicates whether closing the lid
causes the device to go to sleep and opening it causes
the device to wake up.

Kernel driver is fixed:
https://github.com/sonyxperiadev/kernel/commit/8b6dc10acf3a0e7545d84427d8022c365d8ea03d

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I9890af1e659fc4512fc575f290d74c1f2ee28cb9
