### PR TITLE
karin: Use triple buffer for SurfaceFlinger

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -14,4 +14,6 @@
 
 include device/sony/kitakami/PlatformConfig.mk
 
+NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3
+
 TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/maxim_sti/gesture_wakeup"


### PR DESCRIPTION
Sets SurfaceFlinger to use triple buffering.

Reference:
https://source.android.com/devices/graphics/architecture.html#triple-buffering

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I3377c024974b390119569e728b5db4742a711d8d
